### PR TITLE
fix(nav): render issue in safari when nav collapsed

### DIFF
--- a/src/components/Nav/index.less
+++ b/src/components/Nav/index.less
@@ -240,8 +240,11 @@
 
 .@{prefix-cls}-nav__item-icon,
 .@{prefix-cls}-nav__sub-nav-title-icon {
-  margin-right: @ui-unit;
+  margin-right: @ui-unit-double + 2px;
   text-align: center;
+  svg {
+    position: absolute; // fix `float:left` rendering bug in safari
+  }
 }
 
 .@{prefix-cls}-nav__sub-nav-title-toggle {


### PR DESCRIPTION
fix #272

First of all, thank you for your contribution! :-)

Please makes sure that these checkboxes are checked before submitting your PR, thank you!

* [x] Make sure that you propose PR to right branch: bugfix for `master`, feature for latest active branch `feature-x.x`.
* [x] Make sure that you follow earth-ui's [code convention](https://github.com/webapps-ui/core-react/wiki/Code-convention).
* [x] Add some descriptions and refer relative issues(optional) for your PR.
* [x] Add `Assignees`(assign yourself mostly) for your PR.
* [x] Add `Labels` for your PR.

Extra checklist:

**if** *isBugFix* **:**

  * [ ] Make sure that you add at least one unit test for the bug which you had fixed.


**Description**:
cause by `float: left` in svg which makes rendering in safari incorrectly
use `position: absolute` instead

*ScreenShots*:

![image](https://user-images.githubusercontent.com/12554487/81999868-1974ea80-9689-11ea-8a19-470a2a9eaf0e.png)


